### PR TITLE
修改每月显示天数会与实际月数对不上的问题

### DIFF
--- a/src/components/calendar.vue
+++ b/src/components/calendar.vue
@@ -162,13 +162,21 @@ export default {
       return this.thisM + 1
     },
     thisMDLen() {
-      return this.monthDays[this.thisRM]
+      //return this.monthDays[this.thisRM]
+      // 原： return this.monthDays[this.thisRM]  注：这里有错误，导致每月显示天数会与实际情况对不上。
+      //应改为
+      return this.monthDays[this.thisRM - 1]
     },
     prevMDLen() {
       return this.prevLD[this.thisW]
     },
     nextMDLen() {
-      return 42 - this.thisMDLen - this.prevMDLen
+      //return 42 - this.thisMDLen - this.prevMDLen
+       if (this.thisMDLen !== undefined && this.prevMDLen !== undefined) {
+        return 42 - this.thisMDLen - this.prevMDLen;
+      } else {
+        return 0; // 或者其他适当的处理
+      }
     },
   },
   methods: {


### PR DESCRIPTION

`monthDays: [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31],`
`thisRM() {
      //return this.thisM + 1
      return this.thisM + 1
    },`
`thisMDLen() {
       const len = this.monthDays[this.thisRM - 1];   //原来：const len = this.monthDays[this.thisRM];
       console.log('thisMDLen:', len);
       return len;
      //return this.monthDays[this.thisRM]
    },`
**thisRM在上一步进行了+1操作，下一步在数组monthDays中筛选月份时应当进行还原，否则会导致月份对不上的问题**
